### PR TITLE
Implement junction handlers to allow multiple notifications from one junction with different formats to be sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,34 +14,31 @@ Once matched, Junction will create the notification from the optionally provided
 Junction is configured with a yaml file. By default, this file is read from `<APP DIRECTORY>/config/config.yaml`.
 
 Available configuration options and any applicable defaults are described below:
-
-`log-level:` Optional. Defaults to `info`. Can be set to `debug` to output more information during application runtime.
-
-`port:` Optional. Defaults to `8025`. The port to listen on for emails. Do not change if using Docker.
-
-`junctions:` Required. A list of configurations that received emails are matched against.
+|Option|Description|
+|---|---|
+|`log-level:`| Optional. Defaults to `info`. Can be set to `debug` to output more information during application runtime. |
+|`port:`| Optional. Defaults to `8025`. The port to listen on for emails. Do not change if using Docker.|
+|`junctions:`| Required. A list of configurations that received emails are matched against.|
 
 Junctions are configured with the following values.
+|Option|Description|
+|---|---|
+|`name:`| Optional. Just used for easier identification of the junction used. Has no effect on application execution.|
+|`to:`| Optional. If not included, every incoming email will match the this portion of the junction.|
+|&nbsp;&nbsp;`emails:`| A list of email addresses that the received email must be sent to.|
+|&nbsp;&nbsp;`require-all:`| `true` or `false`, defaults to `false`. If set to `true`, and multiple email addresses are listed, every email address listed must be present for the received email to match the junction. If unset, or `false`, only one of the listed email addresses needs to be present.|
+|`from:`| Optional. If not included, every incoming email will match this portion of the junction.|
+|&nbsp;&nbsp;`email:`| Optional. The email address that the received email must be sent from.|
+|&nbsp;&nbsp;`ip:`| Optional. The IP Address of the machine that the received email must be sent from.|
+|&nbsp;&nbsp;`handlers:`| A list of handlers that send the contents of the received email to some apprise URLs.|
 
-`name:` Optional. Just used for easier identification of the junction used. Has no effect on application execution.
-
-`apprise:` Required. The [Apprise URL](https://github.com/caronc/apprise/wiki/URLBasics) to send to.
-
-`to:` Optional. If not included, every incoming email will match the this portion of the junction.
-
-&nbsp;&nbsp;`emails:` A list of email addresses that the received email must be sent to.
-
-&nbsp;&nbsp;`require-all:` `true` or `false`, defaults to `false`. If set to `true`, and multiple email addresses are listed, every email address listed must be present for the received email to match the junction. If unset, or `false`, only one of the listed email addresses needs to be present.
-
-`from:` Optional. If not included, every incoming email will match this portion of the junction.
-
-&nbsp;&nbsp;`email:` Optional. The email address that the received email must be sent from.
-
-&nbsp;&nbsp;`ip:` Optional. The IP Address of the machine that the received email must be sent from.
-
-`title:` Optional. What is displayed in the notification's title. Defaults to the received email's subject. See [templating](#templating) below for further information.
-
-`body:` Optional. What is displayed in the notification's body. Defaults to the received email's subject. See [templating](#templating) below for further information.
+Each handler has these options:
+|Option|Description|
+|---|---|
+|`name:`| Optional. Just used for easier identification of the junction handler used. Has no effect on application execution.|
+|`apprise:`| Required. The [Apprise URL](https://github.com/caronc/apprise/wiki/URLBasics) to send to.|
+|`title:`| Optional. What is displayed in the notification's title. Defaults to the received email's subject. See [templating](#templating) below for further information.|
+|`body:`| Optional. What is displayed in the notification's body. Defaults to the received email's subject. See [templating](#templating) below for further information.|
 
 
 **Junctions are matched top down. More specific conditions should be placed to the top, and broader to the bottom**
@@ -52,7 +49,8 @@ Junctions are configured with the following values.
 Minimal:
 ```yaml
 junctions:
-  - apprise: <Apprise URL>
+  - handlers:
+    - apprise: <Apprise URL>
 ```
 With this configuration, every email received will be sent to the provided Apprise URL.
 
@@ -63,7 +61,6 @@ log-level: debug
 port: 25
 junctions:
   - name: Very Specific
-    apprise: <Apprise URL>
     to:
       emails:
         - person1@example.com
@@ -72,24 +69,27 @@ junctions:
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: Less Specific
-    apprise: <Apprise URL>
     to:
       emails:
         - person1@example.com
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: Less Specific 2
-    apprise: <Apprise URL>
     to:
       emails:
         - person2@example.com
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: Less Less Specific
-    apprise: <Apprise URL>
     to:
       emails:
         - person1@example.com
@@ -97,22 +97,28 @@ junctions:
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: No To
-    apprise: <Apprise URL>
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: No To
-    apprise: <Apprise URL>
     from:
       email: server@example.com
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: No To 2
-    apprise: <Apprise URL>
     from:
       ip: 1.1.1.1
+    - handlers:
+        - apprise: <Apprise URL>
   - name: Catch All
-    apprise: <Apprise URL>
+    - handlers:
+        - apprise: <Apprise URL>
 ```
 With this configuration:
 - Extra information will be output by the application for debugging
@@ -194,3 +200,4 @@ If desired, you can change the location of the configuration file with the `CONF
 - [ ] SMTP server authentication
 - [ ] Optional configuration web UI
 - [ ] Option to save emails in a database
+

--- a/email.go
+++ b/email.go
@@ -77,25 +77,33 @@ func mailHandler(remoteIP net.Addr, from string, to []string, data []byte) error
 	junction := junctions[index]
 
 	// Prepare the title and body for the message
-	title, body, url := buildMessage(EmailData{
-		to,
-		from,
-		emailSubject,
-		emailBody,
-		emailDate,
-		ip,
-	}, junction)
+	for handler_index, junction_handler := range junction.Handlers {
+		title, body, url := buildMessage(EmailData{
+			to,
+			from,
+			emailSubject,
+			emailBody,
+			emailDate,
+			ip,
+		}, junction_handler)
 
-	// Get the index or junction name for the logs
-	id := func() string {
-		if junction.Name == "" {
-			return fmt.Sprint(index)
+		// Get the index or junction name for the logs
+		id := func() string {
+			var handler_name string
+			if junction_handler.Name == "" {
+				handler_name = fmt.Sprint(handler_index)
+			} else {
+				handler_name = junction_handler.Name
+			}
+			if junction.Name == "" {
+				return fmt.Sprintf("%d.%s", index, handler_name)
+			}
+			return fmt.Sprintf("%s.%s", junction.Name, handler_name)
 		}
-		return junction.Name
-	}
 
-	// Send it
-	log.Info().Str("junction id", id()).Msg("Sending Notification")
-	sendNotification(title, body, url)
+		// Send it
+		log.Info().Str("junction id", id()).Msg("Sending Notification")
+		sendNotification(title, body, url)
+	}
 	return nil
 }

--- a/junctions.go
+++ b/junctions.go
@@ -8,7 +8,7 @@ type Junction struct {
 	Name    string   `yaml:"name,omitempty"`
 	To      JuncTo   `yaml:"to,omitempty"`
 	From    JuncFrom `yaml:"from,omitempty"`
-	Handlers []JunctionHandler `yaml:"handlers,omitempty"`
+	Handlers []JunctionHandler `yaml:"handlers"`
 }
 
 type JunctionHandler struct {

--- a/junctions.go
+++ b/junctions.go
@@ -6,11 +6,17 @@ import (
 
 type Junction struct {
 	Name    string   `yaml:"name,omitempty"`
-	Apprise string   `yaml:"apprise"`
 	To      JuncTo   `yaml:"to,omitempty"`
 	From    JuncFrom `yaml:"from,omitempty"`
+	Handlers []JunctionHandler `yaml:"handlers,omitempty"`
+}
+
+type JunctionHandler struct {
+	Name    string   `yaml:"name,omitempty"`
+	Apprise string   `yaml:"apprise"`
 	Title   string   `yaml:"title,omitempty"`
 	Body    string   `yaml:"body,omitempty"`
+
 }
 
 type JuncTo struct {

--- a/notify.go
+++ b/notify.go
@@ -15,14 +15,14 @@ buildMessage prepares the title and body of the notification
 Parameters:
 
 	email    - Data from the received email
-	junction - The Junction to send to
+	junction_handler - The Junction Handler to send to
 
 Returns:
 
 	title - The notification title
 	body  - The notification body
 */
-func buildMessage(email EmailData, junction Junction) (title string, body string, url string) {
+func buildMessage(email EmailData, junction_handler JunctionHandler) (title string, body string, url string) {
 	// Prepare the data used by the Template
 	templateData := struct {
 		Subject string   // The received email's subject line
@@ -44,9 +44,9 @@ func buildMessage(email EmailData, junction Junction) (title string, body string
 
 	// If the Junction provides a Title Template, parse it
 	// Else, use the Email Subject
-	if junction.Title != "" {
+	if junction_handler.Title != "" {
 		builder := &strings.Builder{}
-		template, err := template.New("title").Parse(junction.Title)
+		template, err := template.New("title").Parse(junction_handler.Title)
 		if err != nil {
 			log.Error().Err(err).Msg("Can't parse the title")
 		}
@@ -59,9 +59,9 @@ func buildMessage(email EmailData, junction Junction) (title string, body string
 
 	// If the Junction provides a Body Template, parse it
 	// Else use the Email Body
-	if junction.Body != "" {
+	if junction_handler.Body != "" {
 		builder := &strings.Builder{}
-		template, err := template.New("body").Parse(junction.Body)
+		template, err := template.New("body").Parse(junction_handler.Body)
 		if err != nil {
 			log.Error().Err(err).Msg("Can't parse the body")
 		}
@@ -74,7 +74,7 @@ func buildMessage(email EmailData, junction Junction) (title string, body string
 
 	// Build the URL template
 	builder := &strings.Builder{}
-	template, err := template.New("url").Parse(junction.Apprise)
+	template, err := template.New("url").Parse(junction_handler.Apprise)
 	if err != nil {
 		log.Error().Err(err).Msg("Can't parse the url")
 	}


### PR DESCRIPTION
Implement junction handlers to allow multiple notifications from one junction with different formats to be sent.
This is achieved by adding handlers option which is a list of handlers defined by name, apprise url, title, body. Subsequently each junction now has to define handlers for it to do anything instead of apprise option.
I tried to make as few changes as possible to the existing code.